### PR TITLE
[Refactor#1] add REST controller annotations to AwsController

### DIFF
--- a/src/main/java/com/hackathon/melon/global/aws/AwsController.java
+++ b/src/main/java/com/hackathon/melon/global/aws/AwsController.java
@@ -3,10 +3,12 @@ package com.hackathon.melon.global.aws;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-
+@RestController
+@RequestMapping("/api/aws")
 @RequiredArgsConstructor
-
 public class AwsController {
 
     private final AwsService awsService;


### PR DESCRIPTION
## Summary
   - AwsController에 REST API 엔드포인트를 활성화하기 위한 어노테이션 추가
   - @RestController 어노테이션으로 REST 컨트롤러 지정
   - @RequestMapping("/api/aws")으로 base URL 경로 설정

   ## Changes
   - `@RestController` 추가: 컨트롤러를 RESTful 웹 서비스로 등록
   - `@RequestMapping("/api/aws")` 추가: 모든 AWS 관련 엔드포인트가 `/api/aws` 경로 하위에 매핑됨
   - 불필요한 빈 줄 제거

   ## Test plan
   - [x] 애플리케이션이 정상적으로 시작되는지 확인
   - [x] `/api/aws` 경로로 AWS API 엔드포인트가 정상 동작하는지 테스트
   - [x] 기존 AWS 서비스 기능이 정상 작동하는지 확인
