### PR TITLE
[Feature/#3] GitHub OAuth2 로그인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Application Config (contains sensitive data) ###
+src/main/resources/application.yml
+src/main/resources/application-*.yml

--- a/OAUTH_SETUP.md
+++ b/OAUTH_SETUP.md
@@ -1,0 +1,193 @@
+# GitHub OAuth2 로그인 설정 가이드
+
+## 📋 개요
+
+이 프로젝트는 GitHub OAuth2를 사용하여 사용자 인증을 처리합니다.
+
+## 🛠️ 로컬 개발 환경 설정
+
+### 1. MySQL 데이터베이스 준비
+
+```bash
+mysql -u root -p
+CREATE DATABASE Dlight CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+exit;
+```
+
+### 2. application.yml 설정
+
+1. `src/main/resources/application.yml.example` 파일을 복사하여 `application.yml` 생성
+   ```bash
+   cp src/main/resources/application.yml.example src/main/resources/application.yml
+   ```
+
+2. `application.yml` 파일에서 다음 항목 수정:
+   - `spring.datasource.password`: 본인의 MySQL 비밀번호
+
+### 3. GitHub OAuth App 생성
+
+1. GitHub 설정으로 이동: https://github.com/settings/developers
+2. "New OAuth App" 클릭
+3. 다음 정보 입력:
+   - **Application name**: `Dlight-Local` (또는 원하는 이름)
+   - **Homepage URL**: `http://localhost:8080`
+   - **Authorization callback URL**: `http://localhost:8080/login/oauth2/code/github`
+
+     ⚠️ **중요**: 이 URL은 정확히 일치해야 합니다!
+
+4. "Register application" 클릭
+5. **Client ID**와 **Client Secret** 복사
+
+### 4. 환경변수 설정
+
+#### IntelliJ IDEA 사용 시:
+
+1. **Run > Edit Configurations...**
+2. **MelonApplication** 선택 (없으면 생성)
+3. **Environment variables** 입력:
+   ```
+   GITHUB_CLIENT_ID=your_client_id_here;GITHUB_CLIENT_SECRET=your_client_secret_here
+   ```
+
+#### 터미널에서 실행 시:
+
+```bash
+export GITHUB_CLIENT_ID=your_client_id_here
+export GITHUB_CLIENT_SECRET=your_client_secret_here
+./gradlew bootRun
+```
+
+## 🚀 실행 및 테스트
+
+### 1. 애플리케이션 실행
+
+```bash
+./gradlew bootRun
+```
+
+또는 IntelliJ에서 `MelonApplication` 실행
+
+### 2. OAuth2 로그인 테스트
+
+1. 브라우저에서 접속:
+   ```
+   http://localhost:8080/oauth2/authorization/github
+   ```
+
+2. GitHub 로그인 페이지로 리다이렉트됨
+3. GitHub 계정으로 로그인 및 권한 승인
+4. 로그인 성공 시 `users` 테이블에 사용자 정보 저장됨
+
+### 3. 데이터베이스 확인
+
+```bash
+mysql -u root -p
+USE Dlight;
+SELECT * FROM users;
+```
+
+## 📦 주요 변경 사항
+
+### 1. 의존성 추가 (build.gradle)
+```gradle
+implementation 'org.springframework.boot:spring-boot-starter-security'
+implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+```
+
+### 2. 새로 추가된 파일
+
+```
+src/main/java/com/hackathon/melon/
+├── domain/
+│   ├── auth/
+│   │   └── service/
+│   │       └── CustomOAuth2UserService.java    # OAuth2 사용자 정보 처리
+│   └── user/
+│       ├── entity/
+│       │   └── User.java                        # 사용자 엔티티
+│       └── repository/
+│           └── UserRepository.java              # 사용자 레포지토리
+└── global/
+    └── config/
+        └── swagger/
+            └── SecurityConfig.java              # Spring Security 설정
+```
+
+### 3. 주요 설정
+
+#### SecurityConfig.java
+- OAuth2 로그인 활성화
+- 인증 없이 접근 가능한 경로: `/`, `/health`, `/error`
+- 나머지 경로는 인증 필요
+
+#### CustomOAuth2UserService.java
+- GitHub에서 받은 사용자 정보를 처리
+- 신규 사용자는 DB에 저장
+- 기존 사용자는 정보 업데이트
+
+#### User 엔티티
+- GitHub ID, 로그인명, 프로필 URL, 이메일 저장
+- `BaseEntity` 상속으로 `createdAt`, `updatedAt` 자동 관리
+
+## 🔒 보안 주의사항
+
+1. **절대 커밋하지 말 것:**
+   - `application.yml` (실제 DB 비밀번호 포함)
+   - GitHub Client ID/Secret
+
+2. **이미 .gitignore에 추가됨:**
+   ```
+   src/main/resources/application.yml
+   src/main/resources/application-*.yml
+   ```
+
+3. **팀원과 공유할 파일:**
+   - `application.yml.example` (템플릿)
+   - 이 문서 (`OAUTH_SETUP.md`)
+
+## 🐛 문제 해결
+
+### "Invalid credentials" 에러
+
+**원인**: GitHub OAuth App 설정이 잘못되었거나 환경변수가 설정되지 않음
+
+**해결**:
+1. GitHub OAuth App의 Callback URL 확인
+2. 환경변수 `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` 확인
+3. IntelliJ Run Configuration에서 환경변수 재설정
+
+### 로그인 후 에러 발생
+
+**원인**: MySQL 연결 실패 또는 테이블 생성 실패
+
+**해결**:
+1. MySQL이 실행 중인지 확인
+2. `Dlight` 데이터베이스가 생성되어 있는지 확인
+3. `application.yml`의 DB 비밀번호 확인
+
+### "redirect_uri_mismatch" 에러
+
+**원인**: GitHub OAuth App의 Callback URL이 일치하지 않음
+
+**해결**:
+- GitHub OAuth App 설정에서 Authorization callback URL을 정확히 입력:
+  ```
+  http://localhost:8080/login/oauth2/code/github
+  ```
+
+## 📚 OAuth2 로그인 흐름
+
+```
+1. 사용자 → /oauth2/authorization/github 접속
+2. Spring Security → GitHub 로그인 페이지로 리다이렉트
+3. 사용자 → GitHub에서 로그인 및 권한 승인
+4. GitHub → 인가 코드를 callback URL로 전달
+5. Spring Security → 인가 코드로 액세스 토큰 요청
+6. Spring Security → 액세스 토큰으로 사용자 정보 조회
+7. CustomOAuth2UserService → 사용자 정보 DB 저장/업데이트
+8. 로그인 완료
+```
+
+## 📞 문의
+
+문제가 발생하면 팀 채널에 문의하세요!

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/hackathon/melon/MelonApplication.java
+++ b/src/main/java/com/hackathon/melon/MelonApplication.java
@@ -7,12 +7,14 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-//@EnableJpaAuditing
-@SpringBootApplication(exclude = {
-        DataSourceAutoConfiguration.class,
-        DataSourceTransactionManagerAutoConfiguration.class,
-        HibernateJpaAutoConfiguration.class
-})
+
+//@SpringBootApplication(exclude = {
+//        DataSourceAutoConfiguration.class,
+//        DataSourceTransactionManagerAutoConfiguration.class,
+//        HibernateJpaAutoConfiguration.class
+//})
+@EnableJpaAuditing
+@SpringBootApplication
 public class MelonApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/hackathon/melon/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/hackathon/melon/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,44 @@
+package com.hackathon.melon.domain.auth.service;
+
+import com.hackathon.melon.domain.user.entity.User;
+import com.hackathon.melon.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest req) throws OAuth2AuthenticationException {
+        OAuth2User delegate = super.loadUser(req);
+        Map<String,Object> a = delegate.getAttributes();
+
+        Long githubId  = ((Number)a.get("id")).longValue();
+        String login   = (String) a.get("login");
+        String email   = (String) a.get("email");     // null 가능
+        String htmlUrl = (String) a.get("html_url");
+
+        User user = userRepository.findByGithubId(githubId)
+                .map(u -> { u.setLogin(login); u.setProfileUrl(htmlUrl); u.setEmail(email); return u; })
+                .orElseGet(() -> User.of(githubId, login, htmlUrl, email));
+        userRepository.save(user);
+
+        return new DefaultOAuth2User(
+                List.of(new SimpleGrantedAuthority("ROLE_USER")),
+                a,
+                "id"
+        );
+    }
+}

--- a/src/main/java/com/hackathon/melon/domain/user/entity/User.java
+++ b/src/main/java/com/hackathon/melon/domain/user/entity/User.java
@@ -1,0 +1,34 @@
+package com.hackathon.melon.domain.user.entity;
+
+import com.hackathon.melon.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long githubId;
+
+    private String login;
+    @Column(columnDefinition = "text")
+    private String profileUrl;
+    private String email;
+
+    public static User of(Long githubId, String login, String profileUrl, String email){
+        User u = new User();
+        u.githubId = githubId; u.login = login; u.profileUrl = profileUrl; u.email = email;
+        return u;
+    }
+}

--- a/src/main/java/com/hackathon/melon/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/hackathon/melon/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.hackathon.melon.domain.user.repository;
+
+import com.hackathon.melon.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByGithubId(Long githubId);
+}

--- a/src/main/java/com/hackathon/melon/global/config/swagger/SecurityConfig.java
+++ b/src/main/java/com/hackathon/melon/global/config/swagger/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.hackathon.melon.global.config.swagger;
+
+import com.hackathon.melon.domain.auth.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//        http.csrf(csrf -> csrf.disable());
+//        http.authorizeHttpRequests(auth -> auth
+//                .requestMatchers("/", "/health", "/error").permitAll()
+//                .anyRequest().authenticated()
+//        );
+        http.oauth2Login(oauth -> oauth
+                .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
+                // .successHandler(oAuth2SuccessHandler)   // TODO: 구현 필요
+                // .failureHandler(oAuth2FailureHandler)   // TODO: 구현 필요
+        );
+        //TODO: login 후에 화면 어디로 갈지 api 설정 필요
+        http.logout(l -> l.logoutSuccessUrl("/"));
+        return http.build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,0 @@
-logging:
-  level:
-    root: info
-    com.hackathon.melon: debug
-    software.amazon.awssdk: warn

--- a/src/main/resources/application.yml.example
+++ b/src/main/resources/application.yml.example
@@ -1,0 +1,33 @@
+logging:
+  level:
+    root: info
+    com.hackathon.melon: debug
+    software.amazon.awssdk: warn
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/Dlight?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: YOUR_MYSQL_PASSWORD_HERE
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
+            scope: user:email, read:user
+            redirect-uri: "{baseUrl}/login/oauth2/code/github"
+            client-name: GitHub
+        provider:
+          github:
+            user-name-attribute: id


### PR DESCRIPTION
### 관련 이슈
**Closes #5 **

- Spring Security & OAuth2 Client 의존성 추가
- GitHub OAuth2 로그인 flow 구현
- User 엔티티 및 Repository 생성 (BaseEntity 상속)
- CustomOAuth2UserService로 사용자 정보 자동 저장/업데이트
- SecurityConfig에서 OAuth2 로그인 및 권한 설정
- MySQL 연결 및 JPA Auditing 활성화
- application.yml을 .gitignore에 추가하여 민감정보 보호
- 팀원을 위한 설정 가이드(OAUTH_SETUP.md) 작성
- application.yml.example 템플릿 제공
