### PR TITLE
[Feature/#6] GitHub 레포지토리 및 브랜치 조회 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/hackathon/melon/domain/github/controller/GitHubController.java
+++ b/src/main/java/com/hackathon/melon/domain/github/controller/GitHubController.java
@@ -1,0 +1,82 @@
+package com.hackathon.melon.domain.github.controller;
+
+import com.hackathon.melon.domain.github.dto.BranchDto;
+import com.hackathon.melon.domain.github.dto.RepositoryDto;
+import com.hackathon.melon.domain.github.service.GitHubService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * GitHub API 연동 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/github")
+@RequiredArgsConstructor
+public class GitHubController {
+
+    private final GitHubService gitHubService;
+
+    /**
+     * 현재 로그인한 사용자의 GitHub 레포지토리 목록 조회
+     *
+     * @param authorizedClient OAuth2 인증 클라이언트
+     * @return 레포지토리 목록
+     */
+    @GetMapping("/repos")
+    public ResponseEntity<List<RepositoryDto>> getUserRepositories(
+            @RegisteredOAuth2AuthorizedClient("github") OAuth2AuthorizedClient authorizedClient) {
+
+        if (authorizedClient == null) {
+            log.warn("인증되지 않은 사용자의 레포지토리 조회 시도");
+            return ResponseEntity.status(401).build();
+        }
+
+        log.info("사용자 레포지토리 목록 조회: principalName = {}", authorizedClient.getPrincipalName());
+
+        try {
+            List<RepositoryDto> repositories = gitHubService.getUserRepositories(authorizedClient);
+            return ResponseEntity.ok(repositories);
+        } catch (Exception e) {
+            log.error("레포지토리 목록 조회 실패", e);
+            return ResponseEntity.status(500).build();
+        }
+    }
+
+    /**
+     * 특정 레포지토리의 브랜치 목록 조회
+     *
+     * @param authorizedClient OAuth2 인증 클라이언트
+     * @param owner 레포지토리 소유자
+     * @param repo 레포지토리 이름
+     * @return 브랜치 목록
+     */
+    @GetMapping("/repos/{owner}/{repo}/branches")
+    public ResponseEntity<List<BranchDto>> getRepositoryBranches(
+            @RegisteredOAuth2AuthorizedClient("github") OAuth2AuthorizedClient authorizedClient,
+            @PathVariable String owner,
+            @PathVariable String repo) {
+
+        if (authorizedClient == null) {
+            log.warn("인증되지 않은 사용자의 브랜치 조회 시도");
+            return ResponseEntity.status(401).build();
+        }
+
+        log.info("레포지토리 브랜치 목록 조회: principalName = {}, owner = {}, repo = {}",
+                authorizedClient.getPrincipalName(), owner, repo);
+
+        try {
+            List<BranchDto> branches = gitHubService.getRepositoryBranches(authorizedClient, owner, repo);
+            return ResponseEntity.ok(branches);
+        } catch (Exception e) {
+            log.error("브랜치 목록 조회 실패: {}/{}", owner, repo, e);
+            return ResponseEntity.status(500).build();
+        }
+    }
+}

--- a/src/main/java/com/hackathon/melon/domain/github/dto/BranchDto.java
+++ b/src/main/java/com/hackathon/melon/domain/github/dto/BranchDto.java
@@ -1,0 +1,32 @@
+package com.hackathon.melon.domain.github.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * GitHub Branch 정보 DTO
+ */
+@Data
+public class BranchDto {
+
+    private String name;
+
+    private Commit commit;
+
+    @JsonProperty("protected")
+    private Boolean isProtected;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    /**
+     * Branch의 Commit 정보
+     */
+    @Data
+    public static class Commit {
+        private String sha;
+        private String url;
+    }
+}

--- a/src/main/java/com/hackathon/melon/domain/github/dto/RepositoryDto.java
+++ b/src/main/java/com/hackathon/melon/domain/github/dto/RepositoryDto.java
@@ -1,0 +1,70 @@
+package com.hackathon.melon.domain.github.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * GitHub Repository 정보 DTO
+ */
+@Data
+public class RepositoryDto {
+
+    private Long id;
+
+    private String name;
+
+    @JsonProperty("full_name")
+    private String fullName;
+
+    private String description;
+
+    @JsonProperty("private")
+    private Boolean isPrivate;
+
+    @JsonProperty("html_url")
+    private String htmlUrl;
+
+    @JsonProperty("clone_url")
+    private String cloneUrl;
+
+    @JsonProperty("ssh_url")
+    private String sshUrl;
+
+    @JsonProperty("default_branch")
+    private String defaultBranch;
+
+    private Owner owner;
+
+    @JsonProperty("pushed_at")
+    private String pushedAt;
+
+    private String language;
+
+    @JsonProperty("stargazers_count")
+    private Integer stargazersCount;
+
+    @JsonProperty("watchers_count")
+    private Integer watchersCount;
+
+    @JsonProperty("forks_count")
+    private Integer forksCount;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    /**
+     * Repository Owner 정보
+     */
+    @Data
+    public static class Owner {
+        private String login;
+
+        @JsonProperty("avatar_url")
+        private String avatarUrl;
+
+        @JsonProperty("html_url")
+        private String htmlUrl;
+    }
+}

--- a/src/main/java/com/hackathon/melon/domain/github/service/GitHubService.java
+++ b/src/main/java/com/hackathon/melon/domain/github/service/GitHubService.java
@@ -1,0 +1,68 @@
+package com.hackathon.melon.domain.github.service;
+
+import com.hackathon.melon.domain.github.dto.BranchDto;
+import com.hackathon.melon.domain.github.dto.RepositoryDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+/**
+ * GitHub API 호출 서비스 (WebClient + OAuth2 자동 토큰 관리)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GitHubService {
+
+    private static final String GITHUB_API_BASE_URL = "https://api.github.com";
+
+    private final WebClient webClient;
+
+    /**
+     * 현재 로그인한 사용자의 GitHub 레포지토리 목록 조회
+     *
+     * @param authorizedClient OAuth2 인증 클라이언트
+     * @return 레포지토리 목록
+     */
+    public List<RepositoryDto> getUserRepositories(OAuth2AuthorizedClient authorizedClient) {
+        log.info("GitHub API 호출: 사용자 레포지토리 목록 조회");
+
+        return webClient.get()
+                .uri(GITHUB_API_BASE_URL + "/user/repos?per_page=100&sort=updated")
+                .headers(headers -> headers.set("Accept", "application/vnd.github.v3+json"))
+                .attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction
+                        .oauth2AuthorizedClient(authorizedClient))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<RepositoryDto>>() {})
+                .block();
+    }
+
+    /**
+     * 특정 레포지토리의 브랜치 목록 조회
+     *
+     * @param authorizedClient OAuth2 인증 클라이언트
+     * @param owner 레포지토리 소유자
+     * @param repo 레포지토리 이름
+     * @return 브랜치 목록
+     */
+    public List<BranchDto> getRepositoryBranches(OAuth2AuthorizedClient authorizedClient, String owner, String repo) {
+        log.info("GitHub API 호출: 레포지토리 브랜치 목록 조회 - {}/{}", owner, repo);
+
+        String url = String.format("%s/repos/%s/%s/branches", GITHUB_API_BASE_URL, owner, repo);
+
+        return webClient.get()
+                .uri(url)
+                .headers(headers -> headers.set("Accept", "application/vnd.github.v3+json"))
+                .attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction
+                        .oauth2AuthorizedClient(authorizedClient))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<BranchDto>>() {})
+                .block();
+    }
+}

--- a/src/main/java/com/hackathon/melon/global/config/WebClientConfig.java
+++ b/src/main/java/com/hackathon/melon/global/config/WebClientConfig.java
@@ -1,0 +1,49 @@
+package com.hackathon.melon.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * WebClient + OAuth2 설정
+ */
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(OAuth2AuthorizedClientManager authorizedClientManager) {
+        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2 =
+                new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
+
+        return WebClient.builder()
+                .apply(oauth2.oauth2Configuration())
+                .build();
+    }
+
+    @Bean
+    public OAuth2AuthorizedClientManager authorizedClientManager(
+            ClientRegistrationRepository clientRegistrationRepository,
+            OAuth2AuthorizedClientRepository authorizedClientRepository) {
+
+        OAuth2AuthorizedClientProvider authorizedClientProvider =
+                OAuth2AuthorizedClientProviderBuilder.builder()
+                        .authorizationCode()
+                        .refreshToken()
+                        .build();
+
+        DefaultOAuth2AuthorizedClientManager authorizedClientManager =
+                new DefaultOAuth2AuthorizedClientManager(
+                        clientRegistrationRepository,
+                        authorizedClientRepository);
+        authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
+
+        return authorizedClientManager;
+    }
+}


### PR DESCRIPTION
close #10 

   - GitHub API 연동을 위한 두 개의 엔드포인트 구현 - GET /api/v1/github/repos: 로그인한 사용자의 레포지토리 목록 조회 - GET /api/v1/github/repos/{owner}/{repo}/branches: 특정 레포의 브랜치 목록 조회

   - WebClient + OAuth2 필터 방식으로 GitHub API 호출
     - ServletOAuth2AuthorizedClientExchangeFilterFunction 사용
     - Access Token 자동 관리 및 갱신 - RestTemplate 대신 WebClient 사용으로 코드 간결화

   - DTO 클래스 생성 - RepositoryDto: GitHub 레포지토리 정보 - BranchDto: GitHub 브랜치 정보 - LocalDateTime 타입의 createdAt, updatedAt 필드 추가

   - 의존성 추가
     - spring-boot-starter-webflux 추가 ;