### PR TITLE
[Feature/#10] Project Entity 참조 기준을 Project 에서 User 로 변경

### DIFF
--- a/src/main/java/com/hackathon/melon/domain/auth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/hackathon/melon/domain/auth/handler/OAuth2AuthenticationFailureHandler.java
@@ -46,6 +46,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
                 .queryParam("error", "true")
                 .queryParam("message", exception.getLocalizedMessage())
                 .build()
+                .encode()  // URL 인코딩 추가
                 .toUriString();
     }
 }

--- a/src/main/java/com/hackathon/melon/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/hackathon/melon/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 @Component
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    //TODO: localhost 3000 으로 왜 빠지지?
+
     @Value("${app.oauth2.redirect-uri:http://localhost:3000}")
     private String frontendUrl;
 

--- a/src/main/java/com/hackathon/melon/domain/deployment/service/DeploymentServiceImpl.java
+++ b/src/main/java/com/hackathon/melon/domain/deployment/service/DeploymentServiceImpl.java
@@ -54,8 +54,9 @@ public class DeploymentServiceImpl implements DeploymentService {
                 .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다. projectId: " + dto.getProjectId()));
         log.info("Found Project: '{}' (ID: {})", project.getProjectName(), project.getId());
 
-        ProjectTarget projectTarget = projectTargetRepository.findByProjectAndIsDefaultTrue(project)
-                .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트의 기본 배포 설정을 찾을 수 없습니다. projectId: " + project.getId()));
+        // Project에서 User를 가져와서 해당 User의 기본 배포 설정 조회
+        ProjectTarget projectTarget = projectTargetRepository.findByUserAndIsDefaultTrue(project.getUser())
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 기본 배포 설정을 찾을 수 없습니다. userId: " + project.getUser().getId()));
 
         log.info("Default Project Target Loaded: ID={}", projectTarget.getId());
         log.info("  - Region: {}", projectTarget.getRegion());

--- a/src/main/java/com/hackathon/melon/domain/project/dto/ProjectTargetRequestDto.java
+++ b/src/main/java/com/hackathon/melon/domain/project/dto/ProjectTargetRequestDto.java
@@ -1,6 +1,6 @@
 package com.hackathon.melon.domain.project.dto;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hackathon.melon.domain.project.entity.EnvType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,13 +8,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ProjectTargetRequestDto {
-    private Long projectId;
+    private Long userId;
     private EnvType env;
     private String roleArn;
     private String externalId;
     private String region;
     private Integer sessionDurationSecs;
 
-    @JsonAlias("default")
-    private boolean Default;
+    @JsonProperty("default")
+    private boolean isDefault;
 }

--- a/src/main/java/com/hackathon/melon/domain/project/dto/ProjectTargetResponseDto.java
+++ b/src/main/java/com/hackathon/melon/domain/project/dto/ProjectTargetResponseDto.java
@@ -10,19 +10,23 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ProjectTargetResponseDto {
     private Long id;
-    private Long projectId;
+    private Long userId;
     private String env;
     private String roleArn;
+    private String externalId;
     private String region;
+    private Integer sessionDurationSecs;
     private boolean isDefault;
 
     public static ProjectTargetResponseDto from(ProjectTarget projectTarget) {
         return ProjectTargetResponseDto.builder()
                 .id(projectTarget.getId())
-                .projectId(projectTarget.getProject().getId())
+                .userId(projectTarget.getUser().getId())
                 .env(projectTarget.getEnv() != null ? projectTarget.getEnv().name() : null)
                 .roleArn(projectTarget.getRoleArn())
+                .externalId(projectTarget.getExternalId())
                 .region(projectTarget.getRegion())
+                .sessionDurationSecs(projectTarget.getSessionDurationSecs())
                 .isDefault(projectTarget.isDefault())
                 .build();
     }

--- a/src/main/java/com/hackathon/melon/domain/project/entity/ProjectTarget.java
+++ b/src/main/java/com/hackathon/melon/domain/project/entity/ProjectTarget.java
@@ -1,5 +1,6 @@
 package com.hackathon.melon.domain.project.entity;
 
+import com.hackathon.melon.domain.user.entity.User;
 import com.hackathon.melon.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,9 +11,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "project_targets", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"project_id", "env"})
-})
+@Table(name = "project_targets",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_env", columnNames = {"user_id", "env"})
+    },
+    indexes = {
+        @Index(name = "idx_user_id", columnList = "user_id"),
+        @Index(name = "idx_user_default", columnList = "user_id, is_default")
+    }
+)
 public class ProjectTarget extends BaseEntity {
 
     @Id
@@ -20,11 +27,11 @@ public class ProjectTarget extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
-    private Project project;
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = true)
+    @Column(name = "env", nullable = true)
     private EnvType env;
 
     @Column(name = "role_arn")
@@ -33,17 +40,18 @@ public class ProjectTarget extends BaseEntity {
     @Column(name = "external_id", columnDefinition = "TEXT")
     private String externalId;
 
+    @Column(name = "region")
     private String region;
 
     @Column(name = "session_duration_secs")
     private Integer sessionDurationSecs;
 
-    @Column(name = "is_default")
+    @Column(name = "is_default", nullable = false)
     private boolean isDefault;
 
     @Builder
-    public ProjectTarget(Project project, EnvType env, String roleArn, String externalId, String region, Integer sessionDurationSecs, boolean isDefault) {
-        this.project = project;
+    public ProjectTarget(User user, EnvType env, String roleArn, String externalId, String region, Integer sessionDurationSecs, boolean isDefault) {
+        this.user = user;
         this.env = env;
         this.roleArn = roleArn;
         this.externalId = externalId;

--- a/src/main/java/com/hackathon/melon/domain/project/repository/ProjectTargetRepository.java
+++ b/src/main/java/com/hackathon/melon/domain/project/repository/ProjectTargetRepository.java
@@ -1,12 +1,16 @@
 package com.hackathon.melon.domain.project.repository;
 
-import com.hackathon.melon.domain.project.entity.Project;
+import com.hackathon.melon.domain.project.entity.EnvType;
 import com.hackathon.melon.domain.project.entity.ProjectTarget;
+import com.hackathon.melon.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProjectTargetRepository extends JpaRepository<ProjectTarget, Long> {
-    Optional<ProjectTarget> findByProjectAndIsDefaultTrue(Project project);
+    Optional<ProjectTarget> findByUserAndIsDefaultTrue(User user);
+    Optional<ProjectTarget> findByUserAndEnv(User user, EnvType env);
+    List<ProjectTarget> findAllByUser(User user);
 }
 

--- a/src/main/java/com/hackathon/melon/domain/project/service/ProjectTargetService.java
+++ b/src/main/java/com/hackathon/melon/domain/project/service/ProjectTargetService.java
@@ -1,10 +1,10 @@
 package com.hackathon.melon.domain.project.service;
 
 import com.hackathon.melon.domain.project.dto.ProjectTargetRequestDto;
-import com.hackathon.melon.domain.project.entity.Project;
 import com.hackathon.melon.domain.project.entity.ProjectTarget;
-import com.hackathon.melon.domain.project.repository.ProjectRepository;
 import com.hackathon.melon.domain.project.repository.ProjectTargetRepository;
+import com.hackathon.melon.domain.user.entity.User;
+import com.hackathon.melon.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,22 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProjectTargetService {
 
-    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
     private final ProjectTargetRepository projectTargetRepository;
 
     @Transactional
     public ProjectTarget createProjectTarget(ProjectTargetRequestDto requestDto) {
-        Project project = projectRepository.findById(requestDto.getProjectId())
-                .orElseThrow(() -> new IllegalArgumentException("Project not found with id: " + requestDto.getProjectId()));
+        User user = userRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + requestDto.getUserId()));
 
         ProjectTarget projectTarget = ProjectTarget.builder()
-                .project(project)
+                .user(user)
                 .env(requestDto.getEnv())
                 .roleArn(requestDto.getRoleArn())
                 .externalId(requestDto.getExternalId())
                 .region(requestDto.getRegion())
                 .sessionDurationSecs(requestDto.getSessionDurationSecs())
-                .isDefault(true)
+                .isDefault(requestDto.isDefault())
                 .build();
 
         return projectTargetRepository.save(projectTarget);

--- a/src/main/java/com/hackathon/melon/global/config/swagger/SecurityConfig.java
+++ b/src/main/java/com/hackathon/melon/global/config/swagger/SecurityConfig.java
@@ -72,12 +72,10 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 허용할 출처 (프론트엔드 URL)
-        //configuration.setAllowedOrigins(List.of(frontendUrl));
-
+        // 허용할 출처 (프론트엔드 URL + 백엔드 자신)
         configuration.setAllowedOrigins(List.of(
-                "http://3.37.87.13:3000",
-                "http://localhost:3000"
+                "http://54.180.117.76:8080",  // 백엔드 자신 (Swagger OAuth2 로그인용)
+                "http://localhost:3000"       // 로컬 개발용 프론트엔드
         ));
 
         // 허용할 HTTP 메서드

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,48 @@
+logging:
+  level:
+    root: info
+    com.hackathon.melon: debug
+    software.amazon.awssdk: warn
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/Dlight?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: 020806
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create  # 로컬에서는 create 사용 가능
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        jdbc.time_zone: Asia/Seoul
+
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_LOCAL_CLIENT_ID}
+            client-secret: ${GITHUB_LOCAL_CLIENT_SECRET}
+            scope: user:email, read:user
+            redirect-uri: "http://localhost:8080/login/oauth2/code/github"
+            client-name: GitHub
+        provider:
+          github:
+            user-name-attribute: id
+
+  deploy:
+    workDir: src/main/resources/workspace
+
+  logging:
+    level:
+      org.springframework.security: DEBUG
+
+# OAuth2 로그인 성공 후 리다이렉트할 URL (로컬 프론트엔드)
+app:
+  oauth2:
+    redirect-uri: http://localhost:8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ logging:
 
 spring:
   profiles:
-    default: prod
+    active: ${SPRING_PROFILES_ACTIVE:local}  # 기본값 local, 배포 시 prod로 설정
 
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:mysql://${DB_HOST:mysql}:${DB_PORT:3306}/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
@@ -16,7 +16,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create  # 프로덕션: validate 또는 none (create는 데이터 삭제 위험!)
     show-sql: false
     properties:
       hibernate:
@@ -40,3 +40,8 @@ spring:
 
   deploy:
     workDir: src/main/resources/workspace
+
+# OAuth2 로그인 성공 후 리다이렉트할 URL (프론트엔드 배포 전까지는 백엔드 URL)
+app:
+  oauth2:
+    redirect-uri: http://54.180.117.76:8080/


### PR DESCRIPTION
# Pull Request

## 📝 변경 사항

  - `ProjectTarget` 엔티티가 `Project` 대신 `User`를 직접 참조하도록 데이터 모델을 리팩토링했습니다. (관련 DTO 및 서비스 로직 수정 포함)
  - 로컬 개발 환경을 위한 `application-local.yml` 설정 파일을 추가했습니다.
  - OAuth2 로그인 실패 핸들러(`OAuth2AuthenticationFailureHandler`)에서 발생하는 URL 인코딩 오류를 수정했습니다.
  - `ProjectTargetRequestDto`의 기본 필드 매핑 오류를 수정했습니다.
  - `local` 및 `prod` 환경에 따라 CORS 및 OAuth2 설정(리디렉션 URI 등)이 분리되어 적용되도록 업데이트했습니다.

## 🔗 관련 이슈

  - Closes \#23
  - Related to \#

## 📡 API 변경 사항 (API 변경인 경우)

API 스펙 변경은 없습니다. (내부 로직 및 DTO 매핑 수정)

**Swagger 문서 업데이트**: [ ] (해당 없음)

## ✅ 체크리스트

  - [ ] 코드가 프로젝트의 코딩 스타일을 준수합니다
  - [ ] 자기 코드를 검토했습니다
  - [ ] 변경 사항에 대한 주석을 작성했습니다 (복잡한 로직의 경우)
  - [ ] 문서가 업데이트되었습니다 (필요한 경우)
  - [ ] 변경 사항으로 인한 경고나 에러가 없습니다
  - [ ] 관련 테스트를 추가하거나 수정했습니다 (필요한 경우)
  - [ ] 모든 테스트가 통과합니다

## 🧪 테스트 방법

### 로컬 테스트

1.  `application-local.yml` (또는 활성화된 로컬 프로필)로 서버를 실행합니다.
2.  `ProjectTarget` 관련 기능을 (생성/조회 등) 실행하여 `User` 기반으로 정상 작동하는지 확인합니다.
3.  로컬 환경에서 OAuth2 로그인을 시도하여 성공하는지 확인합니다.
4.  (가능하다면) OAuth2 로그인 요청을 의도적으로 실패시켜, 에러 메시지와 함께 정상적인 URL로 리디렉션되는지 확인합니다. (URL 인코딩 확인)

### API 테스트 (API 변경인 경우)

```bash
(해당 없음)
```

## 💬 리뷰어에게 전달할 메시지

  - `ProjectTarget` 엔티티의 참조 기준이 `User`로 변경됨에 따라, 관련 서비스 로직(특히 `ProjectTarget` 생성 및 조회)을 중점적으로 확인 부탁드립니다.
  - 로컬 개발 환경(`local`)과 운영 환경(`prod`)의 OAuth2 및 CORS 설정이 프로필에 맞게 잘 분리되었는지 확인이 필요합니다.

## 📋 타입

  - [ ] 🐛 Bug Fix (버그 수정)
  - [ ] ✨ Feature (새로운 기능)
  - [ ] ♻️ Refactor (리팩토링)
  - [x] 📝 Documentation (문서 수정)
  - [ ] 💄 Style (코드 포맷팅, 세미콜론 누락 등)
  - [ ] ⚡️ Performance (성능 개선)
  - [ ] ✅ Test (테스트 추가/수정)
  - [ ] 🔧 Chore (빌드 업무 수정, 패키지 매니저 수정 등)
  - [ ] 🔒 Security (보안 관련)
  - [ ] 🔌 API (API 변경/추가)